### PR TITLE
Implement x86 and x86_64 code generation for functions and scopes

### DIFF
--- a/src/X86.lama
+++ b/src/X86.lama
@@ -411,43 +411,129 @@ fun suffix (op) {
 -- and stack machine code, returns an updated environment and x86 code.
 fun compile (env, code) {
   fun compile (env, code) {
+    fun collectArgs (env, n, acc) {
+      if n == 0
+      then [env, reverse (acc)]
+      else case pop (env) of
+             [arg, envRest] -> collectArgs (envRest, n-1, arg : acc)
+           esac
+      fi
+    }
+
+    fun saveRegisters (regs) {
+      foldl (fun (buf, r) {buf <+ Push (r)}, emptyBuffer (), regs)
+    }
+
+    fun restoreRegisters (regs) {
+      foldl (fun (buf, r) {buf <+ Pop (r)}, emptyBuffer (), reverse (regs))
+    }
+
     foldl (
       fun ([env, scode], i) {
         var code = scode <+ Meta ("# " ++ showSMInsn (i) ++ "\n");
         case i of
           READ ->
-            case env.allocate of
-	      [s, env] -> [env, code <+ Push (edx) <+ Push (ecx) <+ Call ("Lread") <+ Pop (ecx) <+ Pop (edx) <+ Mov (eax, s)]
-            esac             
-        | WRITE ->
-            case env.pop of
-	      [s, env] -> [env, code <+ Push (edx) <+ Push (ecx) <+ Push (s) <+ Call ("Lwrite") <+ Pop (eax) <+ Pop (ecx) <+ Pop (edx)]
+            case allocate (env) of
+              [slot, envRes] -> [envRes, code <+ Push (edx) <+ Push (ecx) <+ Call ("Lread") <+ Pop (ecx) <+ Pop (edx) <+ Mov (eax, slot)]
             esac
-        (* Assignment *)
-        
-         -- Some guidelines for generating function calls:
-         --
-         -- 1. generate instructions to save live registers on the X86 stack (use
-         --    env.liveRegisters (number of arguments);
-         -- 2. generate instructions to move actual parameters from the symbolic
-         --    stack to the hardware one;
-         -- 3. generate the call itself;
-         -- 4. discard the actual parameters from the stack;
-         -- 5. restore saved live registers.
-         --
-         -- Some guidelines for generating functions:
-         --
-         -- 1. generate proper prologue for BEGIN instruction (use "prologue" helper); use
-         --    env.enterFunction to create a proper environment;
-         -- 2. generate epilogue for END instruction.
-               
-        | _ -> failure ("codegeneration for instruction %s is not yet implemented\n", i.string)
-        (* End *)
+        | WRITE ->
+            case pop (env) of
+              [arg, envRes] -> [envRes, code <+ Push (edx) <+ Push (ecx) <+ Push (arg) <+ Call ("Lwrite") <+ Pop (eax) <+ Pop (ecx) <+ Pop (edx)]
+            esac
+        | CONST (n) ->
+            case allocate (env) of
+              [dst, envRes] -> [envRes, code <+> move (L (n), dst)]
+            esac
+        | LD (location) ->
+            case allocate (env) of
+              [dst, envRes] -> [envRes, code <+> move (loc (env, location), dst)]
+            esac
+        | LDA (location) ->
+            [push (env, loc (env, location)), code]
+        | ST (location) ->
+            case pop (env) of
+              [value, envRes] -> [envRes, code <+> move (value, loc (env, location))]
+            esac
+        | STI ->
+            case pop2 (env) of
+              [value, target, envRest] ->
+                var envRes = push (envRest, value);
+                [envRes, code <+> move (value, target)]
+            esac
+        | BINOP (op) ->
+            case pop2 (env) of
+              [rhs, lhs, envRest] ->
+                case allocate (envRest) of
+                  [dst, envRes] ->
+                    var binopCode =
+                      case op of
+                        "/" ->
+                          move (lhs, eax) <+ Cltd <+ IDiv (rhs) <+ move (eax, dst)
+                      | "%" ->
+                          move (lhs, eax) <+ Cltd <+ IDiv (rhs) <+ move (edx, dst)
+                      | "==" -> move (lhs, eax) <+ Binop ("cmp", rhs, eax) <+ Mov (L (0), eax) <+ Set (suffix (op), "%al") <+ move (eax, dst)
+                      | "!=" -> move (lhs, eax) <+ Binop ("cmp", rhs, eax) <+ Mov (L (0), eax) <+ Set (suffix (op), "%al") <+ move (eax, dst)
+                      | "<"  -> move (lhs, eax) <+ Binop ("cmp", rhs, eax) <+ Mov (L (0), eax) <+ Set (suffix (op), "%al") <+ move (eax, dst)
+                      | "<=" -> move (lhs, eax) <+ Binop ("cmp", rhs, eax) <+ Mov (L (0), eax) <+ Set (suffix (op), "%al") <+ move (eax, dst)
+                      | ">"  -> move (lhs, eax) <+ Binop ("cmp", rhs, eax) <+ Mov (L (0), eax) <+ Set (suffix (op), "%al") <+ move (eax, dst)
+                      | ">=" -> move (lhs, eax) <+ Binop ("cmp", rhs, eax) <+ Mov (L (0), eax) <+ Set (suffix (op), "%al") <+ move (eax, dst)
+                      | _     -> move (lhs, eax) <+ Binop (op, rhs, eax) <+ move (eax, dst)
+                      esac;
+                    [envRes, code <+> binopCode]
+                esac
+            esac
+        | LABEL (lab) ->
+            [retrieveStack (env, lab), code <+ Label (lab)]
+        | JMP (lab) ->
+            [setBarrier (setStack (env, lab)), code <+ Jmp (lab)]
+        | CJMP (cond, lab) ->
+            case pop (env) of
+              [value, envRest] ->
+                var envRes = setStack (envRest, lab);
+                [envRes, code <+> move (value, eax) <+ Binop ("cmp", L (0), eax) <+ CJmp (cond, lab)]
+            esac
+        | CALL (lab, nArgs) ->
+            var regs = liveRegisters (env, nArgs);
+            case collectArgs (env, nArgs, {}) of
+              [envRest, args] ->
+                var pushSaved = saveRegisters (regs);
+                var restoreSaved = restoreRegisters (regs);
+                var pushArgs = foldl (fun (buf, arg) {buf <+ Push (arg)}, emptyBuffer (), reverse (args));
+                var cleanup = if nArgs == 0 then emptyBuffer () else singletonBuffer (Binop ("+", L (nArgs * wordSize), esp)) fi;
+                case allocate (envRest) of
+                  [dst, envRes] ->
+                    [envRes,
+                     code <+>
+                     pushSaved <+>
+                     pushArgs <+>
+                     singletonBuffer (Call (lab)) <+>
+                     cleanup <+>
+                     restoreSaved <+>
+                     move (eax, dst)]
+                esac
+            esac
+        | BEGIN (f, _, locals) ->
+            [enterFunction (env, f, locals), code <+> prologue (f)]
+        | GLOBAL (name) ->
+            [addGlobal (env, name), code]
+        | END ->
+            case epilogue (env) of
+              [envRes, epilogueCode] -> [envRes, code <+> epilogueCode]
+            esac
+        | DUP ->
+            var top = peek (env);
+            case allocate (env) of
+              [dst, envRes] -> [envRes, code <+> move (top, dst)]
+            esac
+        | DROP ->
+            case pop (env) of
+              [_, envRes] -> [envRes, code]
+            esac
         esac
       }, [env, emptyBuffer ()], code)
   }
 
-  compile (env, code) 
+  compile (env, code)
 }
 
 -- A top-level codegeneration function. Takes a driver's environment and a stack machine program,

--- a/src/X86_64.lama
+++ b/src/X86_64.lama
@@ -478,7 +478,63 @@ fun savecode (env, nA) {
 -- 4. discard those parameters that were passed through stack from the stack;
 -- 5. restore saved live registers.         
 fun call (env, fLabel, nA) {
-  failure ("calls not implemented")
+  fun collectArgs (env, n, acc) {
+    if n == 0
+    then [env, reverse (acc)]
+    else case pop (env) of
+           [arg, envRest] -> collectArgs (envRest, n-1, arg : acc)
+         esac
+    fi
+  }
+
+  fun length (xs) {
+    foldl (fun (n, _) {n + 1}, 0, xs)
+  }
+
+  fun popRegArgs (regs, count) {
+    if count == 0
+    then emptyBuffer ()
+    else case regs of
+           r : rest -> singletonBuffer (Pop (r)) <+ popRegArgs (rest, count - 1)
+         esac
+    fi
+  }
+
+  var regs = liveRegisters (env, nA);
+  var saved = length (regs);
+
+  case collectArgs (env, nA, {}) of
+    [envArgs, args] ->
+      var regArgs = if nA < nRegArgs then nA else nRegArgs fi;
+      var stackArgs = if nA > nRegArgs then nA - nRegArgs else 0 fi;
+      var returnsValue = compare (fLabel, "Lwrite") != 0;
+
+      var pushSaved = foldl (fun (buf, r) {buf <+ Push (r)}, emptyBuffer (), regs);
+      var restoreSaved = foldl (fun (buf, r) {buf <+ Pop (r)}, emptyBuffer (), reverse (regs));
+      var pushArgs = foldl (fun (buf, arg) {buf <+ Push (arg)}, emptyBuffer (), reverse (args));
+      var argRegs = {rdi, rsi, rdx, rcx, r8, r9};
+      var moveRegs = popRegArgs (argRegs, regArgs);
+
+      var needAlign = (saved + stackArgs) % 2 != 0;
+      var alignBuffer = if needAlign then singletonBuffer (Push (L (0))) else emptyBuffer () fi;
+      var stackCleanup = if needAlign then stackArgs + 1 else stackArgs fi;
+      var cleanupBuffer = if stackCleanup == 0 then emptyBuffer () else singletonBuffer (Binop ("+", L (stackCleanup * wordSize), rsp)) fi;
+
+      var callBuffer =
+        pushSaved <+>
+        pushArgs <+>
+        moveRegs <+>
+        alignBuffer <+>
+        singletonBuffer (Call (fLabel)) <+>
+        cleanupBuffer <+>
+        restoreSaved;
+
+      if returnsValue
+      then case allocate (envArgs) of
+             [dst, envRes] -> [envRes, callBuffer <+> move (rax, dst)]
+           esac
+      else [envArgs, callBuffer]
+  esac
 }
 
 -- Gets a suffix for Set instruction from
@@ -502,24 +558,90 @@ fun compile (env, code) {
       var code = scode <+ Meta ("# " ++ showSMInsn (i) ++ "\n");
 
       -- printf ("compiling %s\n", showSMInsn (i));
-      
-      case i of      
+
+      case i of
         READ ->
           let [env, callCode] = call (env, "Lread", 0) in
-	  [env, code <+> callCode]
+          [env, code <+> callCode]
       | WRITE ->
           let [env, callCode] = call (env, "Lwrite", 1) in
-	  [env, code <+> callCode]
-	  
-      (* Assignment        
-         -- Some guidelines for generating functions:
-         --
-         -- 1. generate proper prologue for BEGIN instruction (use "prologue" helper); use
-         --    env.enterFunction to create a proper environment;
-         -- 2. generate epilogue for END instruction.
-      *)
-        
-      | _ -> failure ("codegeneration for instruction %s is not yet implemented\n", i.string)
+          [env, code <+> callCode]
+
+      | CONST (n) ->
+          case allocate (env) of
+            [dst, envRes] -> [envRes, code <+> move (L (n), dst)]
+          esac
+      | LD (location) ->
+          case allocate (env) of
+            [dst, envRes] -> [envRes, code <+> move (loc (env, location), dst)]
+          esac
+      | LDA (location) ->
+          [push (env, loc (env, location)), code]
+      | ST (location) ->
+          case pop (env) of
+            [value, envRes] -> [envRes, code <+> move (value, loc (env, location))]
+          esac
+      | STI ->
+          case pop2 (env) of
+            [value, target, envRest] ->
+              var envRes = push (envRest, value);
+              [envRes, code <+> move (value, target)]
+          esac
+      | BINOP (op) ->
+          case pop2 (env) of
+            [rhs, lhs, envRest] ->
+              case allocate (envRest) of
+                [dst, envRes] ->
+                  var binopCode =
+                    case op of
+                      "/" ->
+                        (withRDX (envRest,
+                                   move (lhs, rax) <+ Cltd <+ IDiv (rhs)) <+>
+                         move (rax, dst))
+                    | "%" ->
+                        withRDX (envRest,
+                                 move (lhs, rax) <+ Cltd <+ IDiv (rhs) <+ move (rdx, dst))
+                    | "==" -> move (lhs, rax) <+ Binop ("cmp", rhs, rax) <+ move (L (0), rax) <+ Set (suffix (op), "%al") <+ move (rax, dst)
+                    | "!=" -> move (lhs, rax) <+ Binop ("cmp", rhs, rax) <+ move (L (0), rax) <+ Set (suffix (op), "%al") <+ move (rax, dst)
+                    | "<"  -> move (lhs, rax) <+ Binop ("cmp", rhs, rax) <+ move (L (0), rax) <+ Set (suffix (op), "%al") <+ move (rax, dst)
+                    | "<=" -> move (lhs, rax) <+ Binop ("cmp", rhs, rax) <+ move (L (0), rax) <+ Set (suffix (op), "%al") <+ move (rax, dst)
+                    | ">"  -> move (lhs, rax) <+ Binop ("cmp", rhs, rax) <+ move (L (0), rax) <+ Set (suffix (op), "%al") <+ move (rax, dst)
+                    | ">=" -> move (lhs, rax) <+ Binop ("cmp", rhs, rax) <+ move (L (0), rax) <+ Set (suffix (op), "%al") <+ move (rax, dst)
+                    | _     -> move (lhs, rax) <+ Binop (op, rhs, rax) <+ move (rax, dst)
+                    esac;
+                  [envRes, code <+> binopCode]
+              esac
+          esac
+      | LABEL (lab) ->
+          [retrieveStack (env, lab), code <+ Label (lab)]
+      | JMP (lab) ->
+          [setBarrier (setStack (env, lab)), code <+ Jmp (lab)]
+      | CJMP (cond, lab) ->
+          case pop (env) of
+            [value, envRest] ->
+              var envRes = setStack (envRest, lab);
+              [envRes, code <+> move (value, rax) <+ Binop ("cmp", L (0), rax) <+ CJmp (cond, lab)]
+          esac
+      | CALL (lab, nArgs) ->
+          let [envRes, callCode] = call (env, lab, nArgs) in
+          [envRes, code <+> callCode]
+      | BEGIN (f, nArgs, locals) ->
+          [enterFunction (env, f, nArgs, locals), code <+> prologue (f)]
+      | GLOBAL (name) ->
+          [addGlobal (env, name), code]
+      | END ->
+          case epilogue (env) of
+            [envRes, epilogueCode] -> [envRes, code <+> epilogueCode]
+          esac
+      | DUP ->
+          var top = peek (env);
+          case allocate (env) of
+            [dst, envRes] -> [envRes, code <+> move (top, dst)]
+          esac
+      | DROP ->
+          case pop (env) of
+            [_, envRes] -> [envRes, code]
+          esac
       esac
     }, [env, emptyBuffer ()], code)
 }


### PR DESCRIPTION
## Summary
- expand the x86 backend to handle all stack-machine instructions including calls, scope handling, and control flow
- implement a full x86_64 call helper honoring the SysV ABI and finish lowering for scopes, functions, and comparisons

## Testing
- `make` *(fails: lamac binary is unavailable in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68c9e0655f3483299a4361b0a0995962